### PR TITLE
兼容最新版微信抓取

### DIFF
--- a/rule/index.js
+++ b/rule/index.js
@@ -7,7 +7,8 @@ const {
   getComments,
   getProfileBasicInfo,
   getPostList,
-  handleProfileHtml
+  handleProfileHtml,
+  getNextPostLink,
 } = require('./wechatRule');
 const basicAuth = require('./basicAuth');
 const config = require('../config');
@@ -80,7 +81,10 @@ const rule = {
       if (!config.rule.profile.disable) {
         nextLink = yield models.Profile.getNextProfileLink();
       }
-      if (!nextLink) nextLink = '';
+      if (!nextLink) {
+        nextLink = yield getNextPostLink();
+        debug('没有需要抓取的公众号了，自动开始文章抓取');
+      }
       debug('nextLink', nextLink);
       return {
         response: {

--- a/rule/wechatRule.js
+++ b/rule/wechatRule.js
@@ -381,7 +381,7 @@ const handleProfileHtml = async function (ctx) {
       const isScrollFn = time => {
         let contentText = document.querySelector('.weui-panel').innerText;
         contentText = contentText.trim();
-        const contentArr = contentText.split('\\n');
+        const contentArr = contentText.split('\\n').filter(function(el) {return el.length != 0});
 
         // 最后一行表示目前抓取的状态
         // 正在加载
@@ -582,4 +582,5 @@ module.exports = {
   getProfileBasicInfo,
   getPostList,
   handleProfileHtml,
+  getNextPostLink,
 };


### PR DESCRIPTION
最新版微信的文章页链接换了，好像改成了长连接传输，抓不到包。
但是直接访问原来的链接也可以抓取数据，所以在公众号抓取完后自动重定向到文章页即可