### PR TITLE
修复历史数据异步加载导致公众号历史消息自动跳转失败的问题。

### DIFF
--- a/rule/wechatRule.js
+++ b/rule/wechatRule.js
@@ -448,7 +448,17 @@ const handleProfileHtml = async function (ctx) {
         controlJump();
       };
 
-      controlScroll();
+      // controlScroll();
+
+      const startControlScroll = () => {
+        if(document.querySelector('.weui-panel').innerText) {
+          controlScroll()
+        } else {
+          setTimeout(startControlScroll, 1000)
+        }
+      }
+
+      startControlScroll();
     });
   })();
 </script>`;


### PR DESCRIPTION
微信进入历史消息页面目前是先进入历史记录页面之后再异步加载数据，代码中是通过判断weui-panel这个元素中的文本来判断的（以前的版本可能是可能加载页面的时候就是已经加载好数据的），因为页面加载初期这个元素中的文本是空的，所以导致页面抓取历史消息失败。
这个PR的操作是在页面加载之后判断weui-panel中的文本已经加载之后再进行页面跳转的操作。